### PR TITLE
実施タスク一覧の表示と実施時間の編集を実装

### DIFF
--- a/src/graph/css/style.css
+++ b/src/graph/css/style.css
@@ -1,5 +1,4 @@
-@import '../../css/normalize.css';
-
+@import 'normalize.css';
 * {
   box-sizing: border-box;
   position: relative;

--- a/src/header/css/header.css
+++ b/src/header/css/header.css
@@ -1,5 +1,4 @@
-@import '../../css/normalize.css';
-
+@import 'normalize.css';
 * {
   box-sizing: border-box;
   position: relative;
@@ -48,7 +47,6 @@ li {
   grid-template-columns: 1fr 1.5fr 6fr 0.5fr;
   gap: 2rem;
 }
-
 .header::before {
   content: "";
   width: 120vw;
@@ -61,29 +59,24 @@ li {
   z-index: 100;
   pointer-events: none;
   transition: all 0.5s ease-in-out;
-  -webkit-clip-path: polygon(100% 0%, 100% 0%, 100% 100%, 100% 100%);
   clip-path: polygon(100% 0%, 100% 0%, 100% 100%, 100% 100%);
 }
-
 .header-logo {
   width: 100%;
   height: 100%;
   position: relative;
 }
-
 .header-logo img {
   height: 2rem;
   position: absolute;
   left: 0;
 }
-
 .header .cal-container {
   width: 100%;
   position: relative;
   display: flex;
   justify-content: flex-start;
 }
-
 .header .cal-container::before {
   content: "";
   width: 1.5rem;
@@ -97,12 +90,10 @@ li {
   left: 0;
   transform: translateY(-50%);
 }
-
 .header .cal-container .cal {
   width: 1.5rem;
   opacity: 0;
 }
-
 .header .cal-container .cal-date {
   display: block;
   white-space: nowrap;
@@ -110,13 +101,11 @@ li {
   font-size: 24px;
   padding-left: 1rem;
 }
-
 .header-username {
   width: 100%;
   height: 100%;
   text-align: end;
 }
-
 .header-humburger {
   height: 100%;
   position: absolute;
@@ -125,7 +114,6 @@ li {
   cursor: pointer;
   z-index: 99999;
 }
-
 .header-humburger-top {
   display: block;
   width: 2rem;
@@ -134,7 +122,6 @@ li {
   transform: translateY(0.7rem);
   transition: all ease-in-out 0.5s 0.1s;
 }
-
 .header-humburger-bottom {
   display: block;
   width: 2rem;
@@ -143,7 +130,6 @@ li {
   transform: translateY(0.4rem);
   transition: all ease-in-out 0.5s;
 }
-
 .header-nav {
   width: 15rem;
   height: 100vh;
@@ -155,32 +141,25 @@ li {
   z-index: 9999;
   transition: all 0.5s ease-in-out;
 }
-
 .header-nav-config {
   display: block;
   margin-bottom: 2rem;
   cursor: pointer;
 }
-
 .header-nav-logout {
   display: block;
   cursor: pointer;
 }
-
 .header.open.header::before {
   opacity: 0.3;
-  -webkit-clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%);
   clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%);
 }
-
 .header.open .header-humburger-top {
   transform: translateY(0.75rem) rotate(15deg);
 }
-
 .header.open .header-humburger-bottom {
   transform: translateY(0.7rem) rotate(345deg);
 }
-
 .header.open .header-nav {
   transform: translateX(-20rem);
 }

--- a/src/header/header.php
+++ b/src/header/header.php
@@ -25,6 +25,7 @@ function header()
     <script src="https://npmcdn.com/flatpickr/dist/l10n/en.js" defer></script>
     <script src="./header/js/header.js" type="module" defer></script>
     <script src="./task/js/task.js" defer></script>
+    <script src="../report/js/edit-time.js" defer></script>
   </head>
 
   <body id="grid-container">

--- a/src/login/css/style.css
+++ b/src/login/css/style.css
@@ -1,5 +1,4 @@
-@import '../../css/normalize.css';
-
+@import 'normalize.css';
 * {
   box-sizing: border-box;
   position: relative;
@@ -72,7 +71,7 @@ body {
   padding-bottom: 25px;
 }
 
-div>input[type=submit] {
+div > input[type=submit] {
   display: block;
   margin: 0 auto;
   margin-top: 5px;
@@ -83,7 +82,7 @@ div>input[type=submit] {
   border-radius: 5px;
 }
 
-div>input[type=submit] {
+div > input[type=submit] {
   background-color: #07B53B;
   color: #fff;
   border: solid 1px #07B53B;

--- a/src/report/calc-time.php
+++ b/src/report/calc-time.php
@@ -1,0 +1,12 @@
+<?php
+namespace report;
+
+function getDailyTotaltime($dailyReports)
+{
+    $totalTime = 0;
+    foreach ($dailyReports as $key => $dailyReport) {
+        $totalTime += strtotime($dailyReport["time"]);
+    }
+    $result = date('H:i:s', $totalTime);
+    return $result;
+}

--- a/src/report/css/style.css
+++ b/src/report/css/style.css
@@ -1,5 +1,4 @@
-@import '../../css/normalize.css';
-
+@import 'normalize.css';
 * {
   box-sizing: border-box;
   position: relative;
@@ -67,6 +66,7 @@ li {
   grid-template-rows: 3fr 1fr;
   gap: 1rem;
   overflow: auto;
+  padding-top: 1rem;
 }
 .report-ul {
   width: 100%;
@@ -78,6 +78,7 @@ li {
 .report-li {
   width: 100%;
   height: 4rem;
+  padding: 0.2rem 0;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -96,8 +97,9 @@ li {
 .report-li-top {
   width: 100%;
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: center;
+  gap: 2rem;
   position: relative;
 }
 .report-li-top .rank {
@@ -124,7 +126,7 @@ li {
 }
 .report-li-bottom {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
 }
 .report-li-bottom-inner {
   display: flex;
@@ -135,6 +137,10 @@ li {
   font-weight: normal;
 }
 .report-li-bottom-inner .daily-time {
+  width: 100%;
+}
+.report-li-bottom-inner .daily-time-input {
+  width: 6rem;
   background-color: transparent;
   border: none;
   font-size: 0.9rem;
@@ -182,4 +188,3 @@ li {
   justify-content: flex-end;
   gap: 2rem;
 }
-

--- a/src/report/css/style.scss
+++ b/src/report/css/style.scss
@@ -34,6 +34,7 @@
         grid-template-rows: 3fr 1fr;
         gap: 1rem;
         overflow: auto;
+        padding-top: 1rem;
 
     }
 
@@ -48,6 +49,7 @@
     &-li {
         width: 100%;
         height: 4rem;
+        padding: .2rem 0;
         display: flex;
         flex-direction: column;
         justify-content: space-between;
@@ -67,8 +69,9 @@
         &-top {
             width: 100%;
             display: flex;
-            justify-content: space-between;
+            justify-content: flex-start;
             align-items: center;
+            gap: 2rem;
             position: relative;
 
             & .rank {
@@ -99,7 +102,7 @@
 
         &-bottom {
             display: flex;
-            justify-content: space-between;
+            justify-content: flex-end;
 
             &-inner {
                 display: flex;
@@ -111,10 +114,16 @@
                 }
 
                 & .daily-time {
-                    background-color: transparent;
-                    border: none;
-                    font-size: .9rem;
-                    font-weight: normal;
+                    width: 100%;
+
+                    &-input{
+                        width: 6rem;
+                        background-color: transparent;
+                        border: none;
+                        font-size: .9rem;
+                        font-weight: normal;
+
+                    }
                 }
             }
 

--- a/src/report/exec-tasks.php
+++ b/src/report/exec-tasks.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace report;
+
+use Exception;
+
+function getExecTask($reportQuery, $userId)
+{
+    if (isset($_POST["edit-time"])) {
+        $editTime = $_POST["edit-time"];
+        $taskLogsId = $_POST["task-logs-id"];
+        if (isTimeType($editTime)) {
+            $execTasks = $reportQuery->editTime($editTime, $taskLogsId, $userId);
+            return $execTasks;
+        }else{
+            $execTasks = $reportQuery->getExecTask($userId);
+            return $execTasks;
+        }
+    } else {
+        $execTasks = $reportQuery->getExecTask($userId);
+        return $execTasks;
+    }
+}
+
+function isTimeType($time)
+{
+    $pattern = '/^(0[0-9]|1[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$/';
+    try{
+        if (preg_match($pattern, $time)) {
+            return true;
+        } else {
+            throw new Exception('時間の入力は00:00:00 ~ 23:59:59で入力してください。');
+            return false;
+        }
+    }catch(Exception $e){
+        echo $e->getMessage();
+    }
+}

--- a/src/report/js/edit-time.js
+++ b/src/report/js/edit-time.js
@@ -1,0 +1,7 @@
+const editTimeElems = document.querySelectorAll(".daily-time-input")
+const taskFormElem = document.querySelectorAll(".report-task-form")
+editTimeElems.forEach((editTimeElem) => {
+    editTimeElem.addEventListener("change", () => {
+        taskFormElem.submit()
+    })
+})

--- a/src/report/report.php
+++ b/src/report/report.php
@@ -1,95 +1,62 @@
-<?php  ?>
+<?php
+
+namespace report;
+
+require_once "./task/query.php";
+require_once "calc-time.php";
+require_once "exec-tasks.php";
+
+use task\Query;
+use function report\getDailyTotaltime;
+use function report\getExecTask;
+
+$userId = 1;
+$reportQuery = new Query();
+
+// 1日に実施したタスクの取得
+$execTasks = getExecTask($reportQuery, $userId);
+// 1日の総合勉強時間の取得
+$dailyTotaltime = getDailyTotaltime($execTasks);
+
+?>
 <div class="report">
   <div class="report-header">
     <span class="report-header-title">
       Task List
     </span>
     <span class="report-header-totaltime">
-      総学習時間: 00:00:00
+      総学習時間: <?php echo $dailyTotaltime; ?>
     </span>
   </div>
-  <form class="report-inner" method="form">
+  <form class="report-inner" method="POST">
     <ul class="report-ul">
-      <li class="report-li">
-        <div class="report-li-top">
-          <span class="rank">
-            1
-          </span>
-          <span class="task-name">
-            提出Quest DB/SQL
-          </span>
-        </div>
-        <div class="report-li-bottom">
-          <div class="report-li-bottom-inner">
-            <label for="daily-time">時間</label>
-            <input class="daily-time" name="daily-time" id="daily-time" value="3:00">
-            </input>
-          </div>
-          <span class="totaltime">
-            合計時間: 14:00:00
-          </span>
-        </div>
-      </li>
-      <li class="report-li">
-        <div class="report-li-top">
-          <span class="rank">
-            1
-          </span>
-          <span class="task-name">
-            提出Quest DB/SQL
-          </span>
-        </div>
-        <div class="report-li-bottom">
-          <div class="report-li-bottom-inner">
-            <label for="daily-time">時間</label>
-            <input class="daily-time" name="daily-time" id="daily-time" value="3:00">
-            </input>
-          </div>
-          <span class="totaltime">
-            合計時間: 14:00:00
-          </span>
-        </div>
-      </li>
-      <li class="report-li">
-        <div class="report-li-top">
-          <span class="rank">
-            1
-          </span>
-          <span class="task-name">
-            提出Quest DB/SQL
-          </span>
-        </div>
-        <div class="report-li-bottom">
-          <div class="report-li-bottom-inner">
-            <label for="daily-time">時間</label>
-            <input class="daily-time" name="daily-time" id="daily-time" value="3:00">
-            </input>
-          </div>
-          <span class="totaltime">
-            合計時間: 14:00:00
-          </span>
-        </div>
-      </li>
-      <li class="report-li">
-        <div class="report-li-top">
-          <span class="rank">
-            1
-          </span>
-          <span class="task-name">
-            提出Quest DB/SQL
-          </span>
-        </div>
-        <div class="report-li-bottom">
-          <div class="report-li-bottom-inner">
-            <label for="daily-time">時間</label>
-            <input class="daily-time" name="daily-time" id="daily-time" value="3:00">
-            </input>
-          </div>
-          <span class="totaltime">
-            合計時間: 14:00:00
-          </span>
-        </div>
-      </li>
+      <?php foreach ($execTasks as $key => $execTask) : ?>
+        <li class="report-li">
+          <form class="report-task-form" method="POST">
+            <input type="hidden" name="task-logs-id" value="<?php echo $execTask["id"] ?>">
+            <div class="report-li-top">
+              <span class="rank">
+                <?php echo $key + 1 ?>
+              </span>
+              <span class="task-name">
+                <?php echo $execTask["name"] ?>
+              </span>
+            </div>
+            <div class="report-li-bottom">
+              <div class="report-li-bottom-inner">
+                <div class="daily-time">
+                  <label for="daily-time">時間:</label>
+                  <input class="daily-time-input" name="edit-time" id="edit-time" value="<?php echo $execTask["time"] ?>">
+                  </input>
+                </div>
+              </div>
+              <span class="totaltime">
+                合計時間: <?php echo $execTask["total_time"] ?>
+              </span>
+            </div>
+          </form>
+        </li>
+      <?php endforeach; ?>
     </ul>
     <div class="report-description">
       <label for="report-textarea">

--- a/src/task/css/style.css
+++ b/src/task/css/style.css
@@ -1,5 +1,4 @@
-@import '../../css/normalize.css';
-
+@import 'normalize.css';
 * {
   box-sizing: border-box;
   position: relative;
@@ -46,7 +45,6 @@ li {
   gap: 1rem;
   overflow: auto;
 }
-
 .task-add {
   width: 100%;
   height: 100%;
@@ -56,21 +54,18 @@ li {
   margin-bottom: 2rem;
   overflow: auto;
 }
-
 .task-add-edit {
   background-color: #fff;
   padding: 0.5rem 2rem;
   border: none;
   border-radius: 10px;
 }
-
 .task-add-submit {
   color: #fff;
   border: none;
   border-radius: 10px;
   background-color: #07B53B;
 }
-
 .task .tasks {
   width: 100%;
   height: 100%;
@@ -79,12 +74,10 @@ li {
   overflow: auto;
   position: relative;
 }
-
 .task .tasks-ul {
   width: 100%;
   overflow: auto;
 }
-
 .task .tasks-li {
   width: 100%;
   height: 50px;
@@ -98,7 +91,6 @@ li {
   overflow: auto;
   position: relative;
 }
-
 .task .tasks-form::before {
   content: "";
   width: 100%;
@@ -108,7 +100,6 @@ li {
   position: absolute;
   bottom: 0;
 }
-
 .task .tasks-item {
   width: 100%;
   display: grid;
@@ -116,30 +107,24 @@ li {
   align-items: center;
   gap: 1rem;
 }
-
 .task .tasks-item.completed {
   opacity: 0.2;
   pointer-events: none;
 }
-
 .task .tasks-item-complete {
   background-color: transparent;
   border: none;
 }
-
 .task .tasks-item-complete-icon {
   fill: none;
   stroke: #07B53B;
 }
-
 .task .tasks-item-complete svg {
   opacity: 0.2;
 }
-
 .task .tasks-item-complete.completed svg {
   opacity: 1;
 }
-
 .task .tasks-item-inner {
   width: 100%;
   height: 100%;
@@ -147,7 +132,6 @@ li {
   align-items: center;
   position: relative;
 }
-
 .task .tasks-item-input {
   width: 100%;
   height: 90%;
@@ -156,11 +140,9 @@ li {
   border: none;
   cursor: pointer;
 }
-
 .task .tasks-item-input:focus {
   border: 1px solid gray;
 }
-
 .task .tasks-item-cancel {
   width: 1rem;
   aspect-ratio: 1/1;
@@ -174,25 +156,20 @@ li {
   cursor: pointer;
   z-index: 99999;
 }
-
 .task .tasks-item-cancel.show {
   opacity: 1;
 }
-
 .task .tasks-item-cancel.show svg path {
   fill: gray;
 }
-
 .task .tasks-item-time {
   text-align: end;
 }
-
 .task .tasks-edit {
   display: flex;
   justify-content: space-around;
   align-items: center;
 }
-
 .task .tasks-edit-rename {
   width: 30px;
   height: 30px;
@@ -200,15 +177,12 @@ li {
   border-radius: 10px;
   cursor: pointer;
 }
-
 .task .tasks-edit-rename.editing {
   background-color: #07B53B;
 }
-
 .task .tasks-edit-rename.editing svg path {
   fill: white;
 }
-
 .task .tasks-edit-trush {
   width: 30px;
   height: 30px;
@@ -216,17 +190,13 @@ li {
   border-radius: 10px;
   cursor: pointer;
 }
-
 .task .tasks-edit-trush:hover {
   background-color: orange;
 }
-
 .task .tasks-edit-trush:hover svg ellipse {
   stroke: white;
 }
-
 .task .tasks-edit-trush:hover svg path {
   fill: white;
   stroke: white;
 }
-

--- a/src/timer/css/style.css
+++ b/src/timer/css/style.css
@@ -1,5 +1,4 @@
-@import '../../css/normalize.css';
-
+@import 'normalize.css';
 * {
   box-sizing: border-box;
   position: relative;
@@ -41,7 +40,6 @@ li {
 .timer {
   height: 100%;
 }
-
 .timer-task-select {
   height: 60px;
   width: 100%;
@@ -49,15 +47,12 @@ li {
   text-align: center;
   border: 1px solid #ccc;
   border-radius: 4px 4px 0 0;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   background-image: url("../images/Arrow_drop_down_big.svg");
   background-position: right 10px center;
   background-repeat: no-repeat;
   background-size: 30px 30px;
 }
-
 .timer-display {
   height: 140px;
   width: 100%;
@@ -70,21 +65,18 @@ li {
   align-items: center;
   justify-content: space-between;
 }
-
 .timer-display-time {
   font-size: 64px;
   font-weight: bold;
   text-align: center;
   width: 70%;
 }
-
 .timer-display-button {
   background: none;
   border: none;
   border-radius: 100%;
   width: 30%;
 }
-
 .timer-display-button img {
   border-radius: 100%;
   color: #ccc;
@@ -92,11 +84,9 @@ li {
   height: 100px;
   width: 100px;
 }
-
 .timer-display-button img:hover {
   filter: opacity(80%);
 }
-
 .timer-display-button .clear {
   display: none;
 }


### PR DESCRIPTION
・実施タスクは、その日に登録されてタイマー実績が発生したタスクのみを取得するようにしています。
・1日の実施時間の降順で並び替えています。
・実施時間をクリックすると時間の編集が可能になっていて、フォーカスを外したタイミングでリクエストが飛んで新しい一覧を取得します。
・ベースとなる一覧の情報がtask_logsテーブルから取得しているため、予定しているタスク一覧からゴミ箱で削除されると一緒に削除されるようになってしまっております。