### PR TITLE
実績時間修正をavg_time,total_timeに反映

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -49,7 +49,7 @@ li {
   grid-template-rows: 3rem 1fr;
   grid-template-columns: 1fr;
   gap: 1rem;
-  overflow: auto;
+  overflow: hidden;
 }
 #grid-container #header {
   grid-area: header;

--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -30,7 +30,7 @@
   grid-template-rows: 3rem 1fr;
   grid-template-columns: 1fr;
   gap: 1rem;
-  overflow: auto;
+  overflow: hidden;
 
 
 

--- a/src/report/css/style.css
+++ b/src/report/css/style.css
@@ -58,18 +58,19 @@ li {
   padding: 0.3rem 0.5rem;
 }
 .report-header-totaltime {
-  font-weight: normal;
+  font-weight: bold;
 }
 .report-inner {
   display: grid;
   grid-template-columns: 1fr;
-  grid-template-rows: 3fr 1fr;
+  grid-template-rows: 3fr;
   gap: 1rem;
   overflow: auto;
   padding-top: 1rem;
 }
 .report-ul {
   width: 100%;
+  padding-top: 0.5rem;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -77,15 +78,17 @@ li {
 }
 .report-li {
   width: 100%;
+}
+.report-li .report-task-form {
+  width: 100%;
   height: 4rem;
   padding: 0.2rem 0;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
+  display: grid;
+  grid-template-rows: 1fr 1fr;
   gap: 0.5rem;
   position: relative;
 }
-.report-li::before {
+.report-li .report-task-form::before {
   content: "";
   width: 100%;
   height: 0.5px;
@@ -148,7 +151,14 @@ li {
 }
 .report-li-bottom .totaltime {
   font-size: 0.9rem;
+  color: #999;
   font-weight: normal;
+}
+.report-li:nth-child(1) .report-li-top .rank {
+  color: white;
+}
+.report-li:nth-child(1) .report-li-top .rank::before {
+  background-color: gold;
 }
 .report-li:nth-child(2) .report-li-top .rank {
   color: white;
@@ -161,12 +171,6 @@ li {
 }
 .report-li:nth-child(3) .report-li-top .rank::before {
   background-color: brown;
-}
-.report-li:nth-child(1) .report-li-top .rank {
-  color: white;
-}
-.report-li:nth-child(1) .report-li-top .rank::before {
-  background-color: gold;
 }
 .report-description label {
   font-size: 1rem;

--- a/src/report/css/style.scss
+++ b/src/report/css/style.scss
@@ -23,7 +23,7 @@
         }
 
         &-totaltime {
-            font-weight: normal;
+            font-weight: bold;
         }
     }
 
@@ -31,15 +31,15 @@
     &-inner {
         display: grid;
         grid-template-columns: 1fr;
-        grid-template-rows: 3fr 1fr;
+        grid-template-rows: 3fr;
         gap: 1rem;
         overflow: auto;
         padding-top: 1rem;
-
     }
 
     &-ul {
         width: 100%;
+        padding-top: .5rem;
         display: flex;
         flex-direction: column;
         gap: .5rem;
@@ -48,22 +48,25 @@
 
     &-li {
         width: 100%;
-        height: 4rem;
-        padding: .2rem 0;
-        display: flex;
-        flex-direction: column;
-        justify-content: space-between;
-        gap: .5rem;
-        position: relative;
 
-        &::before {
-            content: "";
+        & .report-task-form {
             width: 100%;
-            height: .5px;
-            background-color: $black_color;
-            position: absolute;
-            top: 50%;
-            left: 0;
+            height: 4rem;
+            padding: .2rem 0;
+            display: grid;
+            grid-template-rows: 1fr 1fr;
+            gap: .5rem;
+            position: relative;
+
+            &::before {
+                content: "";
+                width: 100%;
+                height: .5px;
+                background-color: $black_color;
+                position: absolute;
+                top: 50%;
+                left: 0;
+            }
         }
 
         &-top {
@@ -116,21 +119,33 @@
                 & .daily-time {
                     width: 100%;
 
-                    &-input{
+                    &-input {
                         width: 6rem;
                         background-color: transparent;
                         border: none;
                         font-size: .9rem;
                         font-weight: normal;
-
                     }
                 }
             }
 
             & .totaltime {
                 font-size: .9rem;
+                color: #999;
                 font-weight: normal;
+            }
+        }
 
+
+        &:nth-child(1) {
+            & .report-li-top {
+                & .rank {
+                    color: white;
+
+                    &::before {
+                        background-color: gold;
+                    }
+                }
             }
         }
 
@@ -157,18 +172,6 @@
                 }
             }
         }
-
-        &:nth-child(1) {
-            & .report-li-top {
-                & .rank {
-                    color: white;
-
-                    &::before {
-                        background-color: gold;
-                    }
-                }
-            }
-        }
     }
 
     &-description {
@@ -185,7 +188,6 @@
             gap: 1rem;
 
             & textarea {
-
                 border: none;
                 border-radius: 10px;
             }

--- a/src/report/exec-tasks.php
+++ b/src/report/exec-tasks.php
@@ -9,8 +9,9 @@ function getExecTask($reportQuery, $userId)
     if (isset($_POST["edit-time"])) {
         $editTime = $_POST["edit-time"];
         $taskLogsId = $_POST["task-logs-id"];
+        $taskId = $_POST["task-id"];
         if (isTimeType($editTime)) {
-            $execTasks = $reportQuery->editTime($editTime, $taskLogsId, $userId);
+            $execTasks = $reportQuery->editTime($editTime, $taskLogsId, $userId, $taskId);
             return $execTasks;
         }else{
             $execTasks = $reportQuery->getExecTask($userId);

--- a/src/report/report.php
+++ b/src/report/report.php
@@ -11,8 +11,8 @@ use function report\getDailyTotaltime;
 use function report\getExecTask;
 
 $userId = 1;
+$date = $_POST["datetime-local"] ?? date("Y-m-d");
 $reportQuery = new Query();
-
 // 1日に実施したタスクの取得
 $execTasks = getExecTask($reportQuery, $userId);
 // 1日の総合勉強時間の取得
@@ -28,12 +28,14 @@ $dailyTotaltime = getDailyTotaltime($execTasks);
       総学習時間: <?php echo $dailyTotaltime; ?>
     </span>
   </div>
-  <form class="report-inner" method="POST">
+  <div class="report-inner" method="POST">
     <ul class="report-ul">
       <?php foreach ($execTasks as $key => $execTask) : ?>
         <li class="report-li">
           <form class="report-task-form" method="POST">
-            <input type="hidden" name="task-logs-id" value="<?php echo $execTask["id"] ?>">
+            <input type="hidden" name="task-logs-id" value="<?php echo $execTask["task_logs_id"] ?>">
+            <input type="hidden" name="task-id" value="<?php echo $execTask["task_id"] ?>">
+            <input type="hidden" name="datetime-local" value="<?php echo $date ?>">
             <div class="report-li-top">
               <span class="rank">
                 <?php echo $key + 1 ?>
@@ -45,8 +47,8 @@ $dailyTotaltime = getDailyTotaltime($execTasks);
             <div class="report-li-bottom">
               <div class="report-li-bottom-inner">
                 <div class="daily-time">
-                  <label for="daily-time">時間:</label>
-                  <input class="daily-time-input" name="edit-time" id="edit-time" value="<?php echo $execTask["time"] ?>">
+                  <label>時間:</label>
+                  <input class="daily-time-input" name="edit-time" value="<?php echo $execTask["time"] ?>">
                   </input>
                 </div>
               </div>
@@ -58,7 +60,7 @@ $dailyTotaltime = getDailyTotaltime($execTasks);
         </li>
       <?php endforeach; ?>
     </ul>
-    <div class="report-description">
+    <form class="report-description">
       <label for="report-textarea">
         今日の振り返り
       </label>
@@ -69,6 +71,6 @@ $dailyTotaltime = getDailyTotaltime($execTasks);
           <button>投稿</button>
         </div>
       </div>
-    </div>
-  </form>
+    </form>
+  </div>
 </div>


### PR DESCRIPTION
・カレンダー選択日時の実施タスク時間を編集した際に、time_reportsテーブルのavg_timeとtotal_timeにもアップデートを追加しています。
・上記の実施タスク一覧のlabelとinputの紐付けを、構文エラーと紐付け不要であったため紐付け削除しました。

・追加でハンバーガーメニューの影響による横スクロール改善のため、CSSの変更を行なっています。